### PR TITLE
fix: miss-configured default to match readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Most operating systems require venv to use python libraries.
+venv

--- a/src/utils/input_parser.star
+++ b/src/utils/input_parser.star
@@ -116,6 +116,6 @@ def default_bridge():
         "min_mem": 0,
         "max_mem": 100,
         "private_key": "0x2101010101010101010101010101010101010101010101010101010101010101",
-        "mode": "latest",
+        "mode": "single:b1",
         "image": DEFAULT_IMAGES["bridge"],
     }


### PR DESCRIPTION
The instructions say `single:b1` should be the default mode, but currently it is set to latest. So here is a PR with a fix for that. @njgheorghita for review